### PR TITLE
Fix `useTransitionMap` 

### DIFF
--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -92,8 +92,6 @@ const useTransition = ({
   return [state, toggle, endTransition];
 };
 
-const initialStateMap = new Map();
-const initialConfigMap = new Map();
 const updateState = (key, status, setStateMap, latestStateMap, timeoutId, onChange) => {
   clearTimeout(timeoutId);
   const state = getState(status);
@@ -118,9 +116,9 @@ const useTransitionMap = ({
   unmountOnExit,
   onStateChange: onChange
 } = {}) => {
-  const [stateMap, setStateMap] = react.useState(initialStateMap);
+  const [stateMap, setStateMap] = react.useState(new Map());
   const latestStateMap = react.useRef(stateMap);
-  const configMap = react.useRef(initialConfigMap);
+  const configMap = react.useRef(new Map());
   const [enterTimeout, exitTimeout] = getTimeout(timeout);
   const setItem = react.useCallback((key, config) => {
     const {

--- a/dist/es/hooks/useTransition.js
+++ b/dist/es/hooks/useTransition.js
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { getState, ENTERED, startOrEnd, getEndStatus, PRE_EXIT, EXITING, getTimeout, nextTick, PRE_ENTER, ENTERING } from './utils.js';
+import { getState, ENTERED, startOrEnd, getTimeout, getEndStatus, PRE_EXIT, nextTick, PRE_ENTER, EXITING, ENTERING } from './utils.js';
 
 const updateState = (status, setState, latestState, timeoutId, onChange) => {
   clearTimeout(timeoutId.current);

--- a/dist/es/hooks/useTransitionMap.js
+++ b/dist/es/hooks/useTransitionMap.js
@@ -1,8 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
-import { ENTERED, startOrEnd, getEndStatus, PRE_EXIT, EXITING, getTimeout, nextTick, PRE_ENTER, ENTERING, getState } from './utils.js';
+import { getTimeout, getEndStatus, PRE_EXIT, nextTick, PRE_ENTER, EXITING, ENTERING, ENTERED, startOrEnd, getState } from './utils.js';
 
-const initialStateMap = new Map();
-const initialConfigMap = new Map();
 const updateState = (key, status, setStateMap, latestStateMap, timeoutId, onChange) => {
   clearTimeout(timeoutId);
   const state = getState(status);
@@ -27,9 +25,9 @@ const useTransitionMap = ({
   unmountOnExit,
   onStateChange: onChange
 } = {}) => {
-  const [stateMap, setStateMap] = useState(initialStateMap);
+  const [stateMap, setStateMap] = useState(new Map());
   const latestStateMap = useRef(stateMap);
-  const configMap = useRef(initialConfigMap);
+  const configMap = useRef(new Map());
   const [enterTimeout, exitTimeout] = getTimeout(timeout);
   const setItem = useCallback((key, config) => {
     const {

--- a/src/hooks/useTransitionMap.js
+++ b/src/hooks/useTransitionMap.js
@@ -12,9 +12,6 @@ import {
   nextTick
 } from './utils';
 
-const initialStateMap = new Map();
-const initialConfigMap = new Map();
-
 const updateState = (key, status, setStateMap, latestStateMap, timeoutId, onChange) => {
   clearTimeout(timeoutId);
   const state = getState(status);
@@ -37,9 +34,9 @@ const useTransitionMap = ({
   unmountOnExit,
   onStateChange: onChange
 } = {}) => {
-  const [stateMap, setStateMap] = useState(initialStateMap);
+  const [stateMap, setStateMap] = useState(new Map());
   const latestStateMap = useRef(stateMap);
-  const configMap = useRef(initialConfigMap);
+  const configMap = useRef(new Map());
   const [enterTimeout, exitTimeout] = getTimeout(timeout);
 
   const setItem = useCallback(


### PR DESCRIPTION
Hi there,

there is a bug when having a `useTransitionMap` in a parent and child component, one hook overwrites the `configMap` and an error occurs:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/1d2fb679-1496-4f69-8701-968affea1dce">

The problem is that useRef doesn't create a new `Map` and therefore both hooks reference to the same `initialConfigMap` Map and overwrite each other.

This PR fixes this by creating a new Map for each hook. I also create this for `initialStateMap` because those don't need to be shared as well besides if this behavior should stay we can change this.

If you have any questions, feel free to ask!