### PR TITLE
fix: pre state not triggered when toggling inside setTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **[Live Demo](https://szhsin.github.io/react-transition-state/)**
 
-[![NPM](https://img.shields.io/npm/v/react-transition-state.svg)](https://www.npmjs.com/package/react-transition-state) [![NPM](https://img.shields.io/npm/dm/react-transition-state)](https://www.npmjs.com/package/react-transition-state) [![NPM](https://img.shields.io/bundlephobia/minzip/react-transition-state)](https://bundlephobia.com/package/react-transition-state) [![Known Vulnerabilities](https://snyk.io/test/github/szhsin/react-transition-state/badge.svg)](https://snyk.io/test/github/szhsin/react-transition-state)
+[![NPM](https://img.shields.io/npm/v/react-transition-state.svg)](https://www.npmjs.com/package/react-transition-state) [![NPM](https://img.shields.io/npm/dm/react-transition-state)](https://www.npmjs.com/package/react-transition-state) [![bundlejs](https://deno.bundlejs.com/?q=react-transition-state&treeshake=%5B%7B+useTransitionState+%7D%5D&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%5D%7D%7D&badge=simple)](https://bundlejs.com/?q=react-transition-state&treeshake=%5B%7B+useTransitionState+%7D%5D&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%5D%7D%7D)
 
 ## Features
 
@@ -14,7 +14,7 @@ Inspired by the [React Transition Group](https://github.com/reactjs/react-transi
 - 🔄 Moving React components in and out of DOM seamlessly.
 - 🚫 Using no [derived state](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html).
 - 🚀 Efficient: each state transition results in at most one extract render for consuming component.
-- 🤏 Tiny: [~1KB](https://bundlephobia.com/package/react-transition-state)(post-treeshaking) and no dependencies, ideal for both component libraries and applications.
+- 🤏 Tiny: [650B](https://bundlejs.com/?q=react-transition-state&treeshake=%5B%7B+useTransitionState+%7D%5D&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%5D%7D%7D)(post-treeshaking) and no dependencies, ideal for both component libraries and applications.
 
 🤔 Not convinced? [See a comparison with _React Transition Group_](#comparisons-with-react-transition-group)
 

--- a/dist/cjs/internal.cjs
+++ b/dist/cjs/internal.cjs
@@ -9,7 +9,7 @@ const STATUS = [
 	"unmounted"
 ];
 const getState = (status) => ({
-	_s: status,
+	$: status,
 	status: STATUS[status],
 	isEnter: status < 3,
 	isMounted: status !== 6,
@@ -25,12 +25,12 @@ const getEndStatus = (status, unmountOnExit) => {
 	}
 };
 const getTimeout = (timeout) => typeof timeout === "object" ? [timeout.enter, timeout.exit] : [timeout, timeout];
-const _setTimeout = (...args) => setTimeout(...args);
-const nextTick = (transitState, status) => _setTimeout(() => {
-	isNaN(document.body.offsetTop) || transitState(status + 1);
-}, 0);
+const nextTick = (callback, config) => {
+	config.r = requestAnimationFrame(() => {
+		config.r = requestAnimationFrame(callback);
+	});
+};
 //#endregion
-exports._setTimeout = _setTimeout;
 exports.getEndStatus = getEndStatus;
 exports.getState = getState;
 exports.getTimeout = getTimeout;

--- a/dist/cjs/useTransitionMap.cjs
+++ b/dist/cjs/useTransitionMap.cjs
@@ -1,80 +1,93 @@
 "use strict";
-const require_utils = require("./utils.cjs");
+const require_internal = require("./internal.cjs");
 let react = require("react");
 //#region src/useTransitionMap.ts
-const updateState = (key, status, setStateMap, latestStateMap, timeoutId, onChange) => {
-	clearTimeout(timeoutId);
-	const state = require_utils.getState(status);
-	const stateMap = new Map(latestStateMap.current);
+const updateState = (key, status, setStateMap, ref, config, onChange) => {
+	if (config) {
+		clearTimeout(config.t);
+		cancelAnimationFrame(config.r);
+	}
+	const state = require_internal.getState(status);
+	const stateMap = new Map(ref.m);
 	stateMap.set(key, state);
 	setStateMap(stateMap);
-	latestStateMap.current = stateMap;
-	onChange && onChange({
+	ref.m = stateMap;
+	onChange?.({
 		key,
 		current: state
 	});
 };
 const useTransitionMap = ({ allowMultiple, enter = true, exit = true, preEnter, preExit, timeout, initialEntered, mountOnEnter, unmountOnExit, onStateChange: onChange } = {}) => {
 	const [stateMap, setStateMap] = (0, react.useState)(/* @__PURE__ */ new Map());
-	const latestStateMap = (0, react.useRef)(stateMap);
-	const configMap = (0, react.useRef)(/* @__PURE__ */ new Map());
-	const [enterTimeout, exitTimeout] = require_utils.getTimeout(timeout);
+	const [ref] = (0, react.useState)({
+		m: stateMap,
+		c: /* @__PURE__ */ new Map()
+	});
+	const [enterTimeout, exitTimeout] = require_internal.getTimeout(timeout);
 	const setItem = (0, react.useCallback)((key, options) => {
 		const { initialEntered: _initialEntered = initialEntered } = options || {};
-		updateState(key, _initialEntered ? 2 : require_utils.startOrEnd(mountOnEnter), setStateMap, latestStateMap);
-		configMap.current.set(key, {});
-	}, [initialEntered, mountOnEnter]);
+		updateState(key, _initialEntered ? 2 : require_internal.startOrEnd(mountOnEnter), setStateMap, ref);
+		ref.c.set(key, { r: 0 });
+	}, [
+		initialEntered,
+		mountOnEnter,
+		ref
+	]);
 	const deleteItem = (0, react.useCallback)((key) => {
-		const newStateMap = new Map(latestStateMap.current);
+		const newStateMap = new Map(ref.m);
 		if (newStateMap.delete(key)) {
 			setStateMap(newStateMap);
-			latestStateMap.current = newStateMap;
-			configMap.current.delete(key);
+			ref.m = newStateMap;
+			ref.c.delete(key);
 			return true;
 		}
 		return false;
-	}, []);
+	}, [ref]);
 	const endTransition = (0, react.useCallback)((key) => {
-		const stateObj = latestStateMap.current.get(key);
-		if (!stateObj) {
+		const state = ref.m.get(key);
+		if (!state) {
 			if (process.env.NODE_ENV !== "production") console.error(`[React-Transition-State] cannot call endTransition: invalid key — ${key}`);
 			return;
 		}
-		const { timeoutId } = configMap.current.get(key);
-		const status = require_utils.getEndStatus(stateObj._s, unmountOnExit);
-		status && updateState(key, status, setStateMap, latestStateMap, timeoutId, onChange);
-	}, [onChange, unmountOnExit]);
+		const status = require_internal.getEndStatus(state.$, unmountOnExit);
+		if (status) updateState(key, status, setStateMap, ref, ref.c.get(key), onChange);
+	}, [
+		onChange,
+		unmountOnExit,
+		ref
+	]);
 	const toggle = (0, react.useCallback)((key, toEnter) => {
-		const stateObj = latestStateMap.current.get(key);
-		if (!stateObj) {
+		const state = ref.m.get(key);
+		if (!state) {
 			if (process.env.NODE_ENV !== "production") console.error(`[React-Transition-State] cannot call toggle: invalid key — ${key}`);
 			return;
 		}
-		const config = configMap.current.get(key);
+		const config = ref.c.get(key);
 		const transitState = (status) => {
-			updateState(key, status, setStateMap, latestStateMap, config.timeoutId, onChange);
+			updateState(key, status, setStateMap, ref, config, onChange);
 			switch (status) {
 				case 1:
-					if (enterTimeout >= 0) config.timeoutId = require_utils._setTimeout(() => endTransition(key), enterTimeout);
+					if (enterTimeout >= 0) config.t = setTimeout(() => endTransition(key), enterTimeout);
 					break;
 				case 4:
-					if (exitTimeout >= 0) config.timeoutId = require_utils._setTimeout(() => endTransition(key), exitTimeout);
+					if (exitTimeout >= 0) config.t = setTimeout(() => endTransition(key), exitTimeout);
 					break;
 				case 0:
 				case 3:
-					config.timeoutId = require_utils.nextTick(transitState, status);
+					require_internal.nextTick(() => transitState(status + 1), config);
 					break;
 			}
 		};
-		const enterStage = stateObj.isEnter;
+		const enterStage = state.isEnter;
 		if (typeof toEnter !== "boolean") toEnter = !enterStage;
 		if (toEnter) {
 			if (!enterStage) {
 				transitState(enter ? preEnter ? 0 : 1 : 2);
-				!allowMultiple && latestStateMap.current.forEach((_, _key) => _key !== key && toggle(_key, false));
+				if (!allowMultiple) ref.m.forEach((_, _key) => _key !== key && toggle(_key, false));
 			}
-		} else if (enterStage) transitState(exit ? preExit ? 3 : 4 : require_utils.startOrEnd(unmountOnExit));
+		} else if (enterStage) transitState(exit ? preExit ? 3 : 4 : require_internal.startOrEnd(unmountOnExit));
 	}, [
+		ref,
 		onChange,
 		endTransition,
 		allowMultiple,
@@ -91,8 +104,12 @@ const useTransitionMap = ({ allowMultiple, enter = true, exit = true, preEnter, 
 		toggle,
 		toggleAll: (0, react.useCallback)((toEnter) => {
 			if (!allowMultiple && toEnter !== false) return;
-			for (const key of latestStateMap.current.keys()) toggle(key, toEnter);
-		}, [allowMultiple, toggle]),
+			for (const key of ref.m.keys()) toggle(key, toEnter);
+		}, [
+			allowMultiple,
+			toggle,
+			ref
+		]),
 		endTransition,
 		setItem,
 		deleteItem

--- a/dist/cjs/useTransitionState.cjs
+++ b/dist/cjs/useTransitionState.cjs
@@ -1,46 +1,54 @@
 "use strict";
-const require_utils = require("./utils.cjs");
+const require_internal = require("./internal.cjs");
 let react = require("react");
 //#region src/useTransitionState.ts
-const updateState = (status, setState, latestState, timeoutId, onChange) => {
-	clearTimeout(timeoutId.current);
-	const state = require_utils.getState(status);
+const updateState = (status, setState, ref, onChange) => {
+	clearTimeout(ref.t);
+	cancelAnimationFrame(ref.r);
+	const state = require_internal.getState(status);
 	setState(state);
-	latestState.current = state;
-	onChange && onChange({ current: state });
+	ref.s = state;
+	onChange?.({ current: state });
 };
 const useTransitionState = ({ enter = true, exit = true, preEnter, preExit, timeout, initialEntered, mountOnEnter, unmountOnExit, onStateChange: onChange } = {}) => {
-	const [state, setState] = (0, react.useState)(() => require_utils.getState(initialEntered ? 2 : require_utils.startOrEnd(mountOnEnter)));
-	const latestState = (0, react.useRef)(state);
-	const timeoutId = (0, react.useRef)(0);
-	const [enterTimeout, exitTimeout] = require_utils.getTimeout(timeout);
+	const [state, setState] = (0, react.useState)(() => require_internal.getState(initialEntered ? 2 : require_internal.startOrEnd(mountOnEnter)));
+	const [ref] = (0, react.useState)({
+		s: state,
+		r: 0
+	});
+	const [enterTimeout, exitTimeout] = require_internal.getTimeout(timeout);
 	const endTransition = (0, react.useCallback)(() => {
-		const status = require_utils.getEndStatus(latestState.current._s, unmountOnExit);
-		status && updateState(status, setState, latestState, timeoutId, onChange);
-	}, [onChange, unmountOnExit]);
+		const status = require_internal.getEndStatus(ref.s.$, unmountOnExit);
+		if (status) updateState(status, setState, ref, onChange);
+	}, [
+		onChange,
+		unmountOnExit,
+		ref
+	]);
 	return [
 		state,
 		(0, react.useCallback)((toEnter) => {
 			const transitState = (status) => {
-				updateState(status, setState, latestState, timeoutId, onChange);
+				updateState(status, setState, ref, onChange);
 				switch (status) {
 					case 1:
-						if (enterTimeout >= 0) timeoutId.current = require_utils._setTimeout(endTransition, enterTimeout);
+						if (enterTimeout >= 0) ref.t = setTimeout(endTransition, enterTimeout);
 						break;
 					case 4:
-						if (exitTimeout >= 0) timeoutId.current = require_utils._setTimeout(endTransition, exitTimeout);
+						if (exitTimeout >= 0) ref.t = setTimeout(endTransition, exitTimeout);
 						break;
 					case 0:
 					case 3:
-						timeoutId.current = require_utils.nextTick(transitState, status);
+						require_internal.nextTick(() => transitState(status + 1), ref);
 						break;
 				}
 			};
-			const enterStage = latestState.current.isEnter;
+			const enterStage = ref.s.isEnter;
 			if (typeof toEnter !== "boolean") toEnter = !enterStage;
 			if (toEnter) !enterStage && transitState(enter ? preEnter ? 0 : 1 : 2);
-			else enterStage && transitState(exit ? preExit ? 3 : 4 : require_utils.startOrEnd(unmountOnExit));
+			else enterStage && transitState(exit ? preExit ? 3 : 4 : require_internal.startOrEnd(unmountOnExit));
 		}, [
+			ref,
 			endTransition,
 			onChange,
 			enter,

--- a/dist/esm/internal.mjs
+++ b/dist/esm/internal.mjs
@@ -8,7 +8,7 @@ const STATUS = [
 	"unmounted"
 ];
 const getState = (status) => ({
-	_s: status,
+	$: status,
 	status: STATUS[status],
 	isEnter: status < 3,
 	isMounted: status !== 6,
@@ -24,9 +24,10 @@ const getEndStatus = (status, unmountOnExit) => {
 	}
 };
 const getTimeout = (timeout) => typeof timeout === "object" ? [timeout.enter, timeout.exit] : [timeout, timeout];
-const _setTimeout = (...args) => setTimeout(...args);
-const nextTick = (transitState, status) => _setTimeout(() => {
-	isNaN(document.body.offsetTop) || transitState(status + 1);
-}, 0);
+const nextTick = (callback, config) => {
+	config.r = requestAnimationFrame(() => {
+		config.r = requestAnimationFrame(callback);
+	});
+};
 //#endregion
-export { _setTimeout, getEndStatus, getState, getTimeout, nextTick, startOrEnd };
+export { getEndStatus, getState, getTimeout, nextTick, startOrEnd };

--- a/dist/esm/useTransitionMap.mjs
+++ b/dist/esm/useTransitionMap.mjs
@@ -1,79 +1,92 @@
-import { _setTimeout, getEndStatus, getState, getTimeout, nextTick, startOrEnd } from "./utils.mjs";
-import { useCallback, useRef, useState } from "react";
+import { getEndStatus, getState, getTimeout, nextTick, startOrEnd } from "./internal.mjs";
+import { useCallback, useState } from "react";
 //#region src/useTransitionMap.ts
-const updateState = (key, status, setStateMap, latestStateMap, timeoutId, onChange) => {
-	clearTimeout(timeoutId);
+const updateState = (key, status, setStateMap, ref, config, onChange) => {
+	if (config) {
+		clearTimeout(config.t);
+		cancelAnimationFrame(config.r);
+	}
 	const state = getState(status);
-	const stateMap = new Map(latestStateMap.current);
+	const stateMap = new Map(ref.m);
 	stateMap.set(key, state);
 	setStateMap(stateMap);
-	latestStateMap.current = stateMap;
-	onChange && onChange({
+	ref.m = stateMap;
+	onChange?.({
 		key,
 		current: state
 	});
 };
 const useTransitionMap = ({ allowMultiple, enter = true, exit = true, preEnter, preExit, timeout, initialEntered, mountOnEnter, unmountOnExit, onStateChange: onChange } = {}) => {
 	const [stateMap, setStateMap] = useState(/* @__PURE__ */ new Map());
-	const latestStateMap = useRef(stateMap);
-	const configMap = useRef(/* @__PURE__ */ new Map());
+	const [ref] = useState({
+		m: stateMap,
+		c: /* @__PURE__ */ new Map()
+	});
 	const [enterTimeout, exitTimeout] = getTimeout(timeout);
 	const setItem = useCallback((key, options) => {
 		const { initialEntered: _initialEntered = initialEntered } = options || {};
-		updateState(key, _initialEntered ? 2 : startOrEnd(mountOnEnter), setStateMap, latestStateMap);
-		configMap.current.set(key, {});
-	}, [initialEntered, mountOnEnter]);
+		updateState(key, _initialEntered ? 2 : startOrEnd(mountOnEnter), setStateMap, ref);
+		ref.c.set(key, { r: 0 });
+	}, [
+		initialEntered,
+		mountOnEnter,
+		ref
+	]);
 	const deleteItem = useCallback((key) => {
-		const newStateMap = new Map(latestStateMap.current);
+		const newStateMap = new Map(ref.m);
 		if (newStateMap.delete(key)) {
 			setStateMap(newStateMap);
-			latestStateMap.current = newStateMap;
-			configMap.current.delete(key);
+			ref.m = newStateMap;
+			ref.c.delete(key);
 			return true;
 		}
 		return false;
-	}, []);
+	}, [ref]);
 	const endTransition = useCallback((key) => {
-		const stateObj = latestStateMap.current.get(key);
-		if (!stateObj) {
+		const state = ref.m.get(key);
+		if (!state) {
 			if (process.env.NODE_ENV !== "production") console.error(`[React-Transition-State] cannot call endTransition: invalid key — ${key}`);
 			return;
 		}
-		const { timeoutId } = configMap.current.get(key);
-		const status = getEndStatus(stateObj._s, unmountOnExit);
-		status && updateState(key, status, setStateMap, latestStateMap, timeoutId, onChange);
-	}, [onChange, unmountOnExit]);
+		const status = getEndStatus(state.$, unmountOnExit);
+		if (status) updateState(key, status, setStateMap, ref, ref.c.get(key), onChange);
+	}, [
+		onChange,
+		unmountOnExit,
+		ref
+	]);
 	const toggle = useCallback((key, toEnter) => {
-		const stateObj = latestStateMap.current.get(key);
-		if (!stateObj) {
+		const state = ref.m.get(key);
+		if (!state) {
 			if (process.env.NODE_ENV !== "production") console.error(`[React-Transition-State] cannot call toggle: invalid key — ${key}`);
 			return;
 		}
-		const config = configMap.current.get(key);
+		const config = ref.c.get(key);
 		const transitState = (status) => {
-			updateState(key, status, setStateMap, latestStateMap, config.timeoutId, onChange);
+			updateState(key, status, setStateMap, ref, config, onChange);
 			switch (status) {
 				case 1:
-					if (enterTimeout >= 0) config.timeoutId = _setTimeout(() => endTransition(key), enterTimeout);
+					if (enterTimeout >= 0) config.t = setTimeout(() => endTransition(key), enterTimeout);
 					break;
 				case 4:
-					if (exitTimeout >= 0) config.timeoutId = _setTimeout(() => endTransition(key), exitTimeout);
+					if (exitTimeout >= 0) config.t = setTimeout(() => endTransition(key), exitTimeout);
 					break;
 				case 0:
 				case 3:
-					config.timeoutId = nextTick(transitState, status);
+					nextTick(() => transitState(status + 1), config);
 					break;
 			}
 		};
-		const enterStage = stateObj.isEnter;
+		const enterStage = state.isEnter;
 		if (typeof toEnter !== "boolean") toEnter = !enterStage;
 		if (toEnter) {
 			if (!enterStage) {
 				transitState(enter ? preEnter ? 0 : 1 : 2);
-				!allowMultiple && latestStateMap.current.forEach((_, _key) => _key !== key && toggle(_key, false));
+				if (!allowMultiple) ref.m.forEach((_, _key) => _key !== key && toggle(_key, false));
 			}
 		} else if (enterStage) transitState(exit ? preExit ? 3 : 4 : startOrEnd(unmountOnExit));
 	}, [
+		ref,
 		onChange,
 		endTransition,
 		allowMultiple,
@@ -90,8 +103,12 @@ const useTransitionMap = ({ allowMultiple, enter = true, exit = true, preEnter, 
 		toggle,
 		toggleAll: useCallback((toEnter) => {
 			if (!allowMultiple && toEnter !== false) return;
-			for (const key of latestStateMap.current.keys()) toggle(key, toEnter);
-		}, [allowMultiple, toggle]),
+			for (const key of ref.m.keys()) toggle(key, toEnter);
+		}, [
+			allowMultiple,
+			toggle,
+			ref
+		]),
 		endTransition,
 		setItem,
 		deleteItem

--- a/dist/esm/useTransitionState.mjs
+++ b/dist/esm/useTransitionState.mjs
@@ -1,45 +1,53 @@
-import { _setTimeout, getEndStatus, getState, getTimeout, nextTick, startOrEnd } from "./utils.mjs";
-import { useCallback, useRef, useState } from "react";
+import { getEndStatus, getState, getTimeout, nextTick, startOrEnd } from "./internal.mjs";
+import { useCallback, useState } from "react";
 //#region src/useTransitionState.ts
-const updateState = (status, setState, latestState, timeoutId, onChange) => {
-	clearTimeout(timeoutId.current);
+const updateState = (status, setState, ref, onChange) => {
+	clearTimeout(ref.t);
+	cancelAnimationFrame(ref.r);
 	const state = getState(status);
 	setState(state);
-	latestState.current = state;
-	onChange && onChange({ current: state });
+	ref.s = state;
+	onChange?.({ current: state });
 };
 const useTransitionState = ({ enter = true, exit = true, preEnter, preExit, timeout, initialEntered, mountOnEnter, unmountOnExit, onStateChange: onChange } = {}) => {
 	const [state, setState] = useState(() => getState(initialEntered ? 2 : startOrEnd(mountOnEnter)));
-	const latestState = useRef(state);
-	const timeoutId = useRef(0);
+	const [ref] = useState({
+		s: state,
+		r: 0
+	});
 	const [enterTimeout, exitTimeout] = getTimeout(timeout);
 	const endTransition = useCallback(() => {
-		const status = getEndStatus(latestState.current._s, unmountOnExit);
-		status && updateState(status, setState, latestState, timeoutId, onChange);
-	}, [onChange, unmountOnExit]);
+		const status = getEndStatus(ref.s.$, unmountOnExit);
+		if (status) updateState(status, setState, ref, onChange);
+	}, [
+		onChange,
+		unmountOnExit,
+		ref
+	]);
 	return [
 		state,
 		useCallback((toEnter) => {
 			const transitState = (status) => {
-				updateState(status, setState, latestState, timeoutId, onChange);
+				updateState(status, setState, ref, onChange);
 				switch (status) {
 					case 1:
-						if (enterTimeout >= 0) timeoutId.current = _setTimeout(endTransition, enterTimeout);
+						if (enterTimeout >= 0) ref.t = setTimeout(endTransition, enterTimeout);
 						break;
 					case 4:
-						if (exitTimeout >= 0) timeoutId.current = _setTimeout(endTransition, exitTimeout);
+						if (exitTimeout >= 0) ref.t = setTimeout(endTransition, exitTimeout);
 						break;
 					case 0:
 					case 3:
-						timeoutId.current = nextTick(transitState, status);
+						nextTick(() => transitState(status + 1), ref);
 						break;
 				}
 			};
-			const enterStage = latestState.current.isEnter;
+			const enterStage = ref.s.isEnter;
 			if (typeof toEnter !== "boolean") toEnter = !enterStage;
 			if (toEnter) !enterStage && transitState(enter ? preEnter ? 0 : 1 : 2);
 			else enterStage && transitState(exit ? preExit ? 3 : 4 : startOrEnd(unmountOnExit));
 		}, [
+			ref,
 			endTransition,
 			onChange,
 			enter,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-transition-state",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-transition-state",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-transition-state",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Zero dependency React transition state machine.",
   "author": "Zheng Song",
   "license": "MIT",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -7,7 +7,7 @@ import {
   EXITING,
   EXITED,
   UNMOUNTED
-} from '../utils';
+} from '../internal';
 
 test('getState', () => {
   expect(getState(PRE_ENTER)).toEqual(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,3 +1,15 @@
+/**
+ * ⚠️ WARNING: INTERNAL TYPES
+ *
+ * These types are INTERNAL and NOT intended for public use.
+ * They may CHANGE WITHOUT NOTICE and do NOT follow semver rules.
+ *
+ * ❌ Do NOT extend or derive types from these.
+ *
+ * Single-character property names are used intentionally
+ * to MINIMIZE bundle size and reduce internal overhead.
+ */
+
 import type { TransitionOptions, TransitionState } from './types';
 
 export const PRE_ENTER = 0;
@@ -19,7 +31,31 @@ export type Status =
   | typeof UNMOUNTED;
 
 /** @internal [INTERNAL ONLY – DO NOT USE] */
-export type State = { _s: Status } & TransitionState;
+export type State = {
+  /** @internal status code */
+  $: Status;
+} & TransitionState;
+
+export interface Config {
+  /** @internal setTimeout Id */
+  t?: number;
+  /** @internal requestAnimationFrame Id */
+  r: number;
+}
+
+export interface TransitionStateRef extends Config {
+  /** @internal the latest state */
+  s: State;
+}
+
+export interface TransitionMapRef<TKey> {
+  /** @internal the latest state map */
+  m: Map<TKey, State>;
+  /** @internal the config map */
+  c: Map<TKey, Config>;
+}
+
+export type SetTimeout = WindowOrWorkerGlobalScope['setTimeout'];
 
 export const STATUS = [
   'preEnter',
@@ -32,7 +68,7 @@ export const STATUS = [
 ] as const;
 
 export const getState = (status: Status): State => ({
-  _s: status,
+  $: status,
   status: STATUS[status],
   isEnter: status < PRE_EXIT,
   isMounted: status !== UNMOUNTED,
@@ -56,14 +92,8 @@ export const getEndStatus = (status: Status, unmountOnExit: boolean | undefined)
 export const getTimeout = (timeout: TransitionOptions['timeout']) =>
   typeof timeout === 'object' ? [timeout.enter, timeout.exit] : [timeout, timeout];
 
-// Wrap setTimeout in a function with spread to ensure it is evaluated at call time.
-// https://github.com/szhsin/react-transition-state/issues/868
-// eslint-disable-next-line @typescript-eslint/no-implied-eval
-const _setTimeout: WindowOrWorkerGlobalScope['setTimeout'] = (...args) => setTimeout(...args);
-export { _setTimeout as setTimeout };
-
-export const nextTick = (transitState: (status: Status) => void, status: Status) =>
-  _setTimeout(() => {
-    // Reading document.body.offsetTop can force browser to repaint before transition to the next state
-    isNaN(document.body.offsetTop) || transitState((status + 1) as Status);
-  }, 0);
+export const nextTick = (callback: () => void, config: Config) => {
+  config.r = requestAnimationFrame(() => {
+    config.r = requestAnimationFrame(callback);
+  });
+};

--- a/src/useTransitionMap.ts
+++ b/src/useTransitionMap.ts
@@ -1,6 +1,6 @@
-import { useRef, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { TransitionMapOptions, TransitionItemOptions, TransitionMapResult } from './types';
-import type { Status, State } from './utils';
+import type { Status, State, TransitionMapRef, Config } from './internal';
 import {
   PRE_ENTER,
   ENTERING,
@@ -12,24 +12,27 @@ import {
   getEndStatus,
   getTimeout,
   nextTick,
-  setTimeout
-} from './utils';
+  type SetTimeout
+} from './internal';
 
 const updateState = <TKey>(
   key: TKey,
   status: Status,
   setStateMap: (newStateMap: Map<TKey, State>) => void,
-  latestStateMap: React.RefObject<Map<TKey, State>>,
-  timeoutId?: number,
+  ref: TransitionMapRef<TKey>,
+  config?: Config,
   onChange?: TransitionMapOptions<TKey>['onStateChange']
 ) => {
-  clearTimeout(timeoutId);
+  if (config) {
+    clearTimeout(config.t);
+    cancelAnimationFrame(config.r);
+  }
   const state = getState(status);
-  const stateMap = new Map(latestStateMap.current);
+  const stateMap = new Map(ref.m);
   stateMap.set(key, state);
   setStateMap(stateMap);
-  latestStateMap.current = stateMap;
-  onChange && onChange({ key, current: state });
+  ref.m = stateMap;
+  onChange?.({ key, current: state });
 };
 
 const useTransitionMap = <TKey>({
@@ -45,35 +48,37 @@ const useTransitionMap = <TKey>({
   onStateChange: onChange
 }: TransitionMapOptions<TKey> = {}): TransitionMapResult<TKey> => {
   const [stateMap, setStateMap] = useState(new Map<TKey, State>());
-  const latestStateMap = useRef(stateMap);
-  const configMap = useRef(new Map<TKey, { timeoutId?: number }>());
+  const [ref] = useState<TransitionMapRef<TKey>>({ m: stateMap, c: new Map() });
   const [enterTimeout, exitTimeout] = getTimeout(timeout);
 
   const setItem = useCallback(
     (key: TKey, options?: TransitionItemOptions) => {
       const { initialEntered: _initialEntered = initialEntered } = options || {};
       const status = _initialEntered ? ENTERED : startOrEnd(mountOnEnter);
-      updateState(key, status, setStateMap, latestStateMap);
-      configMap.current.set(key, {});
+      updateState(key, status, setStateMap, ref);
+      ref.c.set(key, { r: 0 });
     },
-    [initialEntered, mountOnEnter]
+    [initialEntered, mountOnEnter, ref]
   );
 
-  const deleteItem = useCallback((key: TKey) => {
-    const newStateMap = new Map(latestStateMap.current);
-    if (newStateMap.delete(key)) {
-      setStateMap(newStateMap);
-      latestStateMap.current = newStateMap;
-      configMap.current.delete(key);
-      return true;
-    }
-    return false;
-  }, []);
+  const deleteItem = useCallback(
+    (key: TKey) => {
+      const newStateMap = new Map(ref.m);
+      if (newStateMap.delete(key)) {
+        setStateMap(newStateMap);
+        ref.m = newStateMap;
+        ref.c.delete(key);
+        return true;
+      }
+      return false;
+    },
+    [ref]
+  );
 
   const endTransition = useCallback(
     (key: TKey) => {
-      const stateObj = latestStateMap.current.get(key);
-      if (!stateObj) {
+      const state = ref.m.get(key);
+      if (!state) {
         if (process.env.NODE_ENV !== 'production') {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           console.error(`[React-Transition-State] cannot call endTransition: invalid key — ${key}`);
@@ -81,17 +86,16 @@ const useTransitionMap = <TKey>({
         return;
       }
 
-      const { timeoutId } = configMap.current.get(key)!;
-      const status = getEndStatus(stateObj._s, unmountOnExit);
-      status && updateState(key, status, setStateMap, latestStateMap, timeoutId, onChange);
+      const status = getEndStatus(state.$, unmountOnExit);
+      if (status) updateState(key, status, setStateMap, ref, ref.c.get(key), onChange);
     },
-    [onChange, unmountOnExit]
+    [onChange, unmountOnExit, ref]
   );
 
   const toggle = useCallback(
     (key: TKey, toEnter?: boolean) => {
-      const stateObj = latestStateMap.current.get(key);
-      if (!stateObj) {
+      const state = ref.m.get(key);
+      if (!state) {
         if (process.env.NODE_ENV !== 'production') {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           console.error(`[React-Transition-State] cannot call toggle: invalid key — ${key}`);
@@ -99,37 +103,36 @@ const useTransitionMap = <TKey>({
         return;
       }
 
-      const config = configMap.current.get(key)!;
+      const config = ref.c.get(key)!;
 
       const transitState = (status: Status) => {
-        updateState(key, status, setStateMap, latestStateMap, config.timeoutId, onChange);
+        updateState(key, status, setStateMap, ref, config, onChange);
 
         switch (status) {
           case ENTERING:
             if (enterTimeout! >= 0)
-              config.timeoutId = setTimeout(() => endTransition(key), enterTimeout);
+              config.t = (setTimeout as SetTimeout)(() => endTransition(key), enterTimeout);
             break;
 
           case EXITING:
             if (exitTimeout! >= 0)
-              config.timeoutId = setTimeout(() => endTransition(key), exitTimeout);
+              config.t = (setTimeout as SetTimeout)(() => endTransition(key), exitTimeout);
             break;
 
           case PRE_ENTER:
           case PRE_EXIT:
-            config.timeoutId = nextTick(transitState, status);
+            nextTick(() => transitState((status + 1) as Status), config);
             break;
         }
       };
 
-      const enterStage = stateObj.isEnter;
+      const enterStage = state.isEnter;
       if (typeof toEnter !== 'boolean') toEnter = !enterStage;
 
       if (toEnter) {
         if (!enterStage) {
           transitState(enter ? (preEnter ? PRE_ENTER : ENTERING) : ENTERED);
-          !allowMultiple &&
-            latestStateMap.current.forEach((_, _key) => _key !== key && toggle(_key, false));
+          if (!allowMultiple) ref.m.forEach((_, _key) => _key !== key && toggle(_key, false));
         }
       } else {
         if (enterStage) {
@@ -138,6 +141,7 @@ const useTransitionMap = <TKey>({
       }
     },
     [
+      ref,
       onChange,
       endTransition,
       allowMultiple,
@@ -154,9 +158,9 @@ const useTransitionMap = <TKey>({
   const toggleAll = useCallback(
     (toEnter?: boolean) => {
       if (!allowMultiple && toEnter !== false) return;
-      for (const key of latestStateMap.current.keys()) toggle(key, toEnter);
+      for (const key of ref.m.keys()) toggle(key, toEnter);
     },
-    [allowMultiple, toggle]
+    [allowMultiple, toggle, ref]
   );
 
   return { stateMap, toggle, toggleAll, endTransition, setItem, deleteItem };

--- a/src/useTransitionState.ts
+++ b/src/useTransitionState.ts
@@ -1,6 +1,6 @@
-import { useRef, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { TransitionOptions, TransitionResult } from './types';
-import type { Status, State } from './utils';
+import type { Status, State, TransitionStateRef } from './internal';
 import {
   PRE_ENTER,
   ENTERING,
@@ -12,21 +12,21 @@ import {
   getEndStatus,
   getTimeout,
   nextTick,
-  setTimeout
-} from './utils';
+  type SetTimeout
+} from './internal';
 
 const updateState = (
   status: Status,
   setState: (newState: State) => void,
-  latestState: React.RefObject<State>,
-  timeoutId: React.RefObject<number>,
+  ref: TransitionStateRef,
   onChange: TransitionOptions['onStateChange']
 ) => {
-  clearTimeout(timeoutId.current);
+  clearTimeout(ref.t);
+  cancelAnimationFrame(ref.r);
   const state = getState(status);
   setState(state);
-  latestState.current = state;
-  onChange && onChange({ current: state });
+  ref.s = state;
+  onChange?.({ current: state });
 };
 
 export const useTransitionState = ({
@@ -43,37 +43,36 @@ export const useTransitionState = ({
   const [state, setState] = useState(() =>
     getState(initialEntered ? ENTERED : startOrEnd(mountOnEnter))
   );
-  const latestState = useRef(state);
-  const timeoutId = useRef(0);
+  const [ref] = useState<TransitionStateRef>({ s: state, r: 0 });
   const [enterTimeout, exitTimeout] = getTimeout(timeout);
 
   const endTransition = useCallback(() => {
-    const status = getEndStatus(latestState.current._s, unmountOnExit);
-    status && updateState(status, setState, latestState, timeoutId, onChange);
-  }, [onChange, unmountOnExit]);
+    const status = getEndStatus(ref.s.$, unmountOnExit);
+    if (status) updateState(status, setState, ref, onChange);
+  }, [onChange, unmountOnExit, ref]);
 
   const toggle = useCallback(
     (toEnter?: boolean) => {
       const transitState = (status: Status) => {
-        updateState(status, setState, latestState, timeoutId, onChange);
+        updateState(status, setState, ref, onChange);
 
         switch (status) {
           case ENTERING:
-            if (enterTimeout! >= 0) timeoutId.current = setTimeout(endTransition, enterTimeout);
+            if (enterTimeout! >= 0) ref.t = (setTimeout as SetTimeout)(endTransition, enterTimeout);
             break;
 
           case EXITING:
-            if (exitTimeout! >= 0) timeoutId.current = setTimeout(endTransition, exitTimeout);
+            if (exitTimeout! >= 0) ref.t = (setTimeout as SetTimeout)(endTransition, exitTimeout);
             break;
 
           case PRE_ENTER:
           case PRE_EXIT:
-            timeoutId.current = nextTick(transitState, status);
+            nextTick(() => transitState((status + 1) as Status), ref);
             break;
         }
       };
 
-      const enterStage = latestState.current.isEnter;
+      const enterStage = ref.s.isEnter;
       if (typeof toEnter !== 'boolean') toEnter = !enterStage;
 
       if (toEnter) {
@@ -84,6 +83,7 @@ export const useTransitionState = ({
       }
     },
     [
+      ref,
       endTransition,
       onChange,
       enter,

--- a/types/internal.d.ts
+++ b/types/internal.d.ts
@@ -1,3 +1,14 @@
+/**
+ * ⚠️ WARNING: INTERNAL TYPES
+ *
+ * These types are INTERNAL and NOT intended for public use.
+ * They may CHANGE WITHOUT NOTICE and do NOT follow semver rules.
+ *
+ * ❌ Do NOT extend or derive types from these.
+ *
+ * Single-character property names are used intentionally
+ * to MINIMIZE bundle size and reduce internal overhead.
+ */
 import type { TransitionOptions, TransitionState } from './types';
 export declare const PRE_ENTER = 0;
 export declare const ENTERING = 1;
@@ -10,13 +21,29 @@ export declare const UNMOUNTED = 6;
 export type Status = typeof PRE_ENTER | typeof ENTERING | typeof ENTERED | typeof PRE_EXIT | typeof EXITING | typeof EXITED | typeof UNMOUNTED;
 /** @internal [INTERNAL ONLY – DO NOT USE] */
 export type State = {
-    _s: Status;
+    /** @internal status code */
+    $: Status;
 } & TransitionState;
+export interface Config {
+    /** @internal setTimeout Id */
+    t?: number;
+    /** @internal requestAnimationFrame Id */
+    r: number;
+}
+export interface TransitionStateRef extends Config {
+    /** @internal the latest state */
+    s: State;
+}
+export interface TransitionMapRef<TKey> {
+    /** @internal the latest state map */
+    m: Map<TKey, State>;
+    /** @internal the config map */
+    c: Map<TKey, Config>;
+}
+export type SetTimeout = WindowOrWorkerGlobalScope['setTimeout'];
 export declare const STATUS: readonly ["preEnter", "entering", "entered", "preExit", "exiting", "exited", "unmounted"];
 export declare const getState: (status: Status) => State;
 export declare const startOrEnd: (unmounted: boolean | undefined) => 5 | 6;
 export declare const getEndStatus: (status: Status, unmountOnExit: boolean | undefined) => 2 | 5 | 6 | undefined;
 export declare const getTimeout: (timeout: TransitionOptions["timeout"]) => (number | undefined)[];
-declare const _setTimeout: WindowOrWorkerGlobalScope['setTimeout'];
-export { _setTimeout as setTimeout };
-export declare const nextTick: (transitState: (status: Status) => void, status: Status) => number;
+export declare const nextTick: (callback: () => void, config: Config) => void;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "..": {
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
- `preEnter` / `preExit` not firing consistently, even after forcing a reflow
- Fixed the issue by using double `requestAnimationFrame` to guarantee a repaint
